### PR TITLE
Add support for Django 3.2

### DIFF
--- a/foliage/contextmanagers.py
+++ b/foliage/contextmanagers.py
@@ -1,10 +1,11 @@
+import django
 from django.db import transaction
 
 from foliage.utils import build_page_tree, get_site, get_root_page
 
 
 class page_tree(transaction.Atomic):
-    def __init__(self, tree, site=None, using=None, savepoint=True):
+    def __init__(self, tree, site=None, using=None, savepoint=True, durable=False):
         if len(tree) > 1:
             raise ValueError("page_tree expects a tree with a single "
                              "root page. Found {}".format(len(tree)))
@@ -12,7 +13,11 @@ class page_tree(transaction.Atomic):
         self.tree = tree
         self.site = site if site is not None else get_site()
         self.root_page = get_root_page()
-        super().__init__(using, savepoint)
+
+        if django.VERSION < (3,):
+            super().__init__(using, savepoint)
+        else:
+            super().__init__(using, savepoint, durable)
 
     def __enter__(self):
         super().__enter__()  # Start the transaction *first*

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,14 @@
 [tox]
 envlist =
-  py{34,35,36,37}-django111-wagtail113
-  py{34,35,36,37}-django{111,200}-wagtail{230,240}
-  py{35,36,37}-django210-wagtail{230,240}
+  py{37,38,39,310}-django22-wagtail{27,211}
+  py{37,38,39,310}-django32-wagtail215
 
 [testenv]
 commands = pytest
 extras = test
 deps =
-  django111: django>=1.11,<1.12
-  django200: django>=2.0,<2.1
-  django210: django>=2.1,<2.2
-  wagtail113: wagtail>=1.13,<2.0
-  wagtail230: wagtail>=2.3,<2.4
-  wagtail240: wagtail>=2.4,<2.5
+  django22: django>=2.2,<2.3
+  django32: django>=3.2,<3.4
+  wagtail27: wagtail>=2.7,<2.8
+  wagtail211: wagtail>=2.11,<2.12
+  wagtail215: wagtail>=2.15,<2.16


### PR DESCRIPTION
Django 3.2 added a new `durable` argument to the `Transaction` class ([docs](https://docs.djangoproject.com/en/3.2/topics/db/transactions/#controlling-transactions-explicitly), [commit](https://github.com/django/django/commit/3828879eee09da95bf99886c1ae182a36b1d89b3)) which prevents this project from working properly with that version.

This commit adds support for that new argument, while still maintaining backwards compatibility with older versions.

I've also updated the tox testing matrix to target current Django and Wagtail LTS versions.